### PR TITLE
Feature/language code case insensitivity

### DIFF
--- a/src/OrangeJetpack.Localization/LocalizedContentExtensions.cs
+++ b/src/OrangeJetpack.Localization/LocalizedContentExtensions.cs
@@ -212,7 +212,7 @@ namespace OrangeJetpack.Localization
                 throw new ArgumentException("Cannot localize property, no localized property values exist.", nameof(localizedContents));
             }
 
-            var localizedContent = localizedContents.SingleOrDefault(i => i.Key.Equals(language) && !string.IsNullOrWhiteSpace(i.Value));
+            var localizedContent = localizedContents.SingleOrDefault(i => i.Key.Equals(language, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(i.Value));
 
             return localizedContent ?? GetContentForDefaultLanguageOrFirst(localizedContents);
         }

--- a/test/OrangeJetpack.Localization.Tests/LocalizedContentTests.cs
+++ b/test/OrangeJetpack.Localization.Tests/LocalizedContentTests.cs
@@ -189,13 +189,13 @@ namespace OrangeJetpack.Localization.Tests
             const string thirdLanguageCode = "eN";
             const string fourthLanguageCode = "en";
 
-            var contentsOne = new[]
+            var firstContentsArray = new[]
             {
                 new LocalizedContent(firstLanguageCode, "this is english content"),
                 new LocalizedContent(secondLanguageCode, "this is another content")
             };
 
-            var contentsTwo = new[]
+            var secondContentsArray = new[]
             {
                 new LocalizedContent(thirdLanguageCode, "this is english content"),
                 new LocalizedContent(fourthLanguageCode, "this is another content")
@@ -203,14 +203,14 @@ namespace OrangeJetpack.Localization.Tests
 
             var firstObj = new TestClassB
             {
-                PropertyA = contentsOne.First().Serialize(),
-                PropertyB = contentsOne.Last().Serialize()
+                PropertyA = firstContentsArray.First().Serialize(),
+                PropertyB = firstContentsArray.Last().Serialize()
             };
 
             var secondObj = new TestClassB
             {
-                PropertyA = contentsTwo.First().Serialize(),
-                PropertyB = contentsTwo.Last().Serialize()
+                PropertyA = secondContentsArray.First().Serialize(),
+                PropertyB = secondContentsArray.Last().Serialize()
             };
 
             const string localizationRequestLanguage = "en";
@@ -399,6 +399,32 @@ namespace OrangeJetpack.Localization.Tests
             var localized = testClasses.Localize(DEFAULT_LANGUAGE, i => i.PropertyA);
 
             Assert.Equal(notSerializedJson, localized.Single().PropertyA);
+        }
+
+        [Fact]
+        public void LocalizeCollection_ObjectsHaveDifferentLanguageCodeCases_LocalizesCorrectly()
+        {
+            const string firstLanguageCode = "eN";
+            const string secondLanguageCode = "En";
+
+            var contents = new[]
+            {
+                new LocalizedContent(firstLanguageCode, "this is english content"),
+                new LocalizedContent(secondLanguageCode, "this is another content")
+            };
+
+            var testClasses = new[]
+            {
+                new TestClassA {PropertyA = contents.First().Serialize(), PropertyB = contents.First().Serialize()},
+                new TestClassA {PropertyA = contents.Last().Serialize(), PropertyB = contents.Last().Serialize()}
+            };
+
+            var localized = testClasses.Localize<TestClassA>(firstLanguageCode.ToUpper()).ToList();
+
+            Assert.Equal("this is english content", localized.ElementAt(0).PropertyA);
+            Assert.Equal("this is english content", localized.ElementAt(0).PropertyB);
+            Assert.Equal("this is another content", localized.ElementAt(1).PropertyA);
+            Assert.Equal("this is another content", localized.ElementAt(1).PropertyB);
         }
 
         [Fact]

--- a/test/OrangeJetpack.Localization.Tests/LocalizedContentTests.cs
+++ b/test/OrangeJetpack.Localization.Tests/LocalizedContentTests.cs
@@ -182,11 +182,95 @@ namespace OrangeJetpack.Localization.Tests
         }
 
         [Fact]
+        public void LocalizeItem_PropertyHasDifferentCasesAndLowerCaseIsRequested_LocalizesAllProperties()
+        {
+            const string firstLanguageCode = "EN";
+            const string secondLanguageCode = "En";
+            const string thirdLanguageCode = "eN";
+            const string fourthLanguageCode = "en";
+
+            var contentsOne = new[]
+            {
+                new LocalizedContent(firstLanguageCode, "this is english content"),
+                new LocalizedContent(secondLanguageCode, "this is another content")
+            };
+
+            var contentsTwo = new[]
+            {
+                new LocalizedContent(thirdLanguageCode, "this is english content"),
+                new LocalizedContent(fourthLanguageCode, "this is another content")
+            };
+
+            var firstObj = new TestClassB
+            {
+                PropertyA = contentsOne.First().Serialize(),
+                PropertyB = contentsOne.Last().Serialize()
+            };
+
+            var secondObj = new TestClassB
+            {
+                PropertyA = contentsTwo.First().Serialize(),
+                PropertyB = contentsTwo.Last().Serialize()
+            };
+
+            const string localizationRequestLanguage = "en";
+            firstObj.Localize(localizationRequestLanguage);
+            secondObj.Localize(localizationRequestLanguage);
+
+            Assert.Equal("this is english content", firstObj.PropertyA);
+            Assert.Equal("this is another content", firstObj.PropertyB);
+            Assert.Equal("this is english content", secondObj.PropertyA);
+            Assert.Equal("this is another content", secondObj.PropertyB);
+        }
+
+        [Fact]
+        public void LocalizeItem_PropertyHasDifferentCasesAndUpperCaseIsRequested_LocalizesAllProperties()
+        {
+            const string firstLanguageCode = "EN";
+            const string secondLanguageCode = "En";
+            const string thirdLanguageCode = "eN";
+            const string fourthLanguageCode = "en";
+
+            var contentsOne = new[]
+            {
+                new LocalizedContent(firstLanguageCode, "this is english content"),
+                new LocalizedContent(secondLanguageCode, "this is another content")
+            };
+
+            var contentsTwo = new[]
+            {
+                new LocalizedContent(thirdLanguageCode, "this is english content"),
+                new LocalizedContent(fourthLanguageCode, "this is another content")
+            };
+
+            var firstObj = new TestClassB
+            {
+                PropertyA = contentsOne.First().Serialize(),
+                PropertyB = contentsOne.Last().Serialize()
+            };
+
+            var secondObj = new TestClassB
+            {
+                PropertyA = contentsTwo.First().Serialize(),
+                PropertyB = contentsTwo.Last().Serialize()
+            };
+
+            const string localizationRequestLanguage = "EN";
+            firstObj.Localize(localizationRequestLanguage);
+            secondObj.Localize(localizationRequestLanguage);
+
+            Assert.Equal("this is english content", firstObj.PropertyA);
+            Assert.Equal("this is another content", firstObj.PropertyB);
+            Assert.Equal("this is english content", secondObj.PropertyA);
+            Assert.Equal("this is another content", secondObj.PropertyB);
+        }
+
+        [Fact]
         public void LocalizeCollection_MultiplePropertiesNoParamsSpecified_LocalizesCorrectly()
         {
             var localizedField = GetLocalizedContent();
 
-            var testClasses = new []
+            var testClasses = new[]
             {
                 new TestClassA {PropertyA = localizedField, PropertyB = localizedField},
                 new TestClassA {PropertyA = localizedField, PropertyB = localizedField}


### PR DESCRIPTION
Language lookup in properties is now case-insensitive..

This concerns https://github.com/mehalick/OrangeJetpack.Localization/issues/4